### PR TITLE
读取Asset文件的最后一Bit失败

### DIFF
--- a/artplayer-ijk/src/main/java/org/salient/artplayer/ijk/RawDataSourceProvider.java
+++ b/artplayer-ijk/src/main/java/org/salient/artplayer/ijk/RawDataSourceProvider.java
@@ -22,7 +22,7 @@ public class RawDataSourceProvider implements IMediaDataSource {
 
     @Override
     public int readAt(long position, byte[] buffer, int offset, int size) {
-        if (position + 1 >= mMediaBytes.length) {
+        if (position >= mMediaBytes.length) {
             return -1;
         }
 
@@ -33,11 +33,8 @@ public class RawDataSourceProvider implements IMediaDataSource {
             length = (int) (mMediaBytes.length - position);
             if (length > buffer.length)
                 length = buffer.length;
-
-            length--;
         }
         System.arraycopy(mMediaBytes, (int) position, buffer, offset, length);
-
         return length;
     }
 


### PR DESCRIPTION
如果播放moov位于文件尾的mp4, Asset方式播放一定会失败, 失败原因是最后1Bit无法读出, 导致moov解析失败.